### PR TITLE
Added dedicated page for ROSflight

### DIFF
--- a/docs/directory/students/brandon_sutherland.md
+++ b/docs/directory/students/brandon_sutherland.md
@@ -19,7 +19,7 @@ Brandon first became interested in aerial robotics when he learned to build and 
 Brandon has been involved in a number of projects in the lab, most recently ROSflight as an undergraduate and now Cooperative GPS-Denied Navigation as a doctoral student. Brandon is currently working on non-invasive methods of adopting cooperative multi-agent navigation systems onto existing Kalman Filter based single-agent systems.
 
 - [Cooperative GPS Navigation](../../research/projects/cooperative_gps_denied_nav.md)
-- [ROSflight](https://rosflight.org/)
+- [ROSflight](../../research/projects/rosflight.md)
 
 ## Papers
 

--- a/docs/directory/students/ian_reid.md
+++ b/docs/directory/students/ian_reid.md
@@ -28,7 +28,7 @@ He is currently working on ROSflight, a lean open source autopilot.
 It aims to be easily modifiable and understandable for reasearch applicaitons.
 He is also working on comparisons of cutting edge state estimation algorithms for multirotors, fixedwings and eVTOLs.
 
-- [ROSflight](https://rosflight.org/)
+- [ROSflight](../../research/projects/rosflight.md)
 
 ### Past Projects
 Ian has also worked on the GPS-denied landing of eVTOL aircraft using infrared light constellations.

--- a/docs/directory/students/jacob_moore.md
+++ b/docs/directory/students/jacob_moore.md
@@ -27,7 +27,7 @@ He is also working on a project enhancing localization accuracy in GPS-denied re
 
 Please reach out with any questions you may have!
 
-- [ROSflight](https://rosflight.org/)
+- [ROSflight](../../research/projects/rosflight.md)
 - [Cooperative GPS Navigation](../../research/projects/cooperative_gps_denied_nav.md)
 
 ### Past Projects

--- a/docs/research/current_projects.md
+++ b/docs/research/current_projects.md
@@ -39,7 +39,7 @@ TEMPLATE
 
     ![](projects/assets/cooperative_gps_denied_nav/uavs_over_ocean.png){ width=300px }
 
--   [**ROSflight**](https://rosflight.org/)
+-   [**ROSflight**](projects/rosflight.md)
 
     ---
 

--- a/docs/research/projects/rosflight.md
+++ b/docs/research/projects/rosflight.md
@@ -33,7 +33,9 @@ Extensive documentation on the project can be found at the [ROSflight website](h
 
 ## Papers
 
-- [Paper Name Here]({DOI line here})
+- [ROSflight: A lightweight, inexpensive MAV research and development tool](https://doi.org/10.1109/ICUAS.2016.7502584)
+- [ROSplane: Fixed-wing autopilot for education and research](https://doi.org/10.1109/ICUAS.2017.7991397)
+- [ROSflight: A Lean Open-Source Research Autopilot](https://doi.org/10.1109/IROS45743.2020.9341653)
 
 ## Code
 

--- a/docs/research/projects/rosflight.md
+++ b/docs/research/projects/rosflight.md
@@ -1,0 +1,41 @@
+# ROSflight
+
+![](assets/rosflight/logo.png){ width=300px }
+
+ROSflight is a lightweight, open-source flight control firmware and software stack designed for research-oriented unmanned aerial vehicles (UAVs), particularly multirotors and fixed-wing aircraft.
+Its primary motivation is to provide a simple, well-documented, and easily modifiable platform for academic and experimental robotics applications, avoiding much of the complexity of autopilots like ArduPilot or PX4.
+
+Extensive documentation on the project can be found at the [ROSflight website](https://rosflight.org/).
+
+## Sponsors
+
+- [Center for Autonomous Air Mobility & Sensing](https://caams.center/)
+- [AeroVironment](https://www.avinc.com/)
+
+## Personnel
+
+### Students
+- Daniel Koch
+- James Jackson
+- Trey Hendrickson
+- [Ian Reid](../../directory/students/ian_reid.md)
+- [Brandon Sutherland](../../directory/students/brandon_sutherland.md)
+- [Jacob Moore](../../directory/students/jacob_moore.md)
+- Joseph Ritchie
+- Derek Ward
+
+### AeroVironment
+- Phil Tokumaru
+
+### Faculty
+- [Tim McLain](../../directory/faculty.md)
+- [James Usevitch](../../directory/faculty.md)
+
+## Papers
+
+- [Paper Name Here]({DOI line here})
+
+## Code
+
+- [ROSflight GitHub](https://github.com/rosflight)
+


### PR DESCRIPTION
Dedicated page for ROSflight to highlight things that don't necessarily make sense to include on the main website, and to provide a brief overview for visitors.